### PR TITLE
Revert "Don't lose last character of command line."

### DIFF
--- a/standalone/mbi.c
+++ b/standalone/mbi.c
@@ -162,7 +162,7 @@ mbi_relocate_modules(struct mbi *mbi, bool uncompress)
 
     for (int i = mbi->mods_count - 1; i >= 0; i--) {
       size_t target_len = minfo[i].do_inflate ? minfo[i].inflated_size : minfo[i].modlen;
-      block_len -= (minfo[i].slen + 1 + target_len + 0xFFF) & ~0xFFF;
+      block_len -= (minfo[i].slen + target_len + 0xFFF) & ~0xFFF;
     
       if (minfo[i].do_inflate) {
         size_t uncompressed;
@@ -180,7 +180,7 @@ mbi_relocate_modules(struct mbi *mbi, bool uncompress)
       mods[i].mod_end = mods[i].mod_start + target_len;
 
       memcpy((char *)block + block_len + target_len, 
-             (void *)mods[i].string, minfo[i].slen + 1);
+             (void *)mods[i].string, minfo[i].slen);
       mods[i].string = (uintptr_t)((char *)block + block_len + target_len);
     }
     printf("\n");


### PR DESCRIPTION
This reverts commit f95c44ada85866da5bf96f84a6c93d6e5c268ccc.

This commit caused an ELF parsing problem when booting foc_x86_64 with a
'bootstrap' module with 'modlen' of 0x28ff0 bytes and 'slen' of 0x10 bytes,
which adds up to 0x29000 bytes. The problem was caused by the mismatch between
the size calculation in line 135 (without +1) and the +1 introduced by the
commit. The 'slen' calculation in line 128 already covers the whole string
length with zero-termination, so it is not really clear why the additional +1
of this commit would be needed.