### PR TITLE
bender: unconditionally relocate all boot modules

### DIFF
--- a/standalone/elf.c
+++ b/standalone/elf.c
@@ -65,9 +65,7 @@ start_module(struct mbi *mbi, bool uncompress)
     return -1;
   }
 
-  if (uncompress || (mbi->mods_count > 1)) {
-    mbi_relocate_modules(mbi, uncompress);
-  }
+  mbi_relocate_modules(mbi, uncompress);
 
   // skip module after loading
   struct module *m  = (struct module *) mbi->mods_addr;


### PR DESCRIPTION
If just one multiboot kernel module was loaded after bender, the
relocation was skipped before. This resulted in a corrupt binary image
on ELF loading if the regions of the boot module and the final program
overlap. Now, all modules are copied below 2 GiB (and out of the way)
before ELF loading.

Fixes #4