### PR TITLE
Support to restrict max physical relocation

### DIFF
--- a/standalone/bender.c
+++ b/standalone/bender.c
@@ -10,6 +10,7 @@
 
 /* Configuration (set by command line parser) */
 static bool be_promisc = false;
+static uint64_t phys_max_relocate = 1ULL << 31; /* below 2G */
 
 void
 parse_cmdline(const char *cmdline)
@@ -32,6 +33,8 @@ parse_cmdline(const char *cmdline)
     if (strcmp(token, "promisc") == 0) {
       be_promisc = true;
     }
+    if (strcmp(token, "phys_max=256M") == 0)
+      phys_max_relocate = 256ULL * 1024 * 1024;
   }
 }
 
@@ -104,5 +107,5 @@ main(uint32_t magic, struct mbi *mbi)
 
   printf("Bender: Hello World.\n");
 
-  return start_module(mbi, false);
+  return start_module(mbi, false, phys_max_relocate);
 }

--- a/standalone/elf.c
+++ b/standalone/elf.c
@@ -58,14 +58,14 @@ gen_elf_segment(uint8_t **code, uintptr_t target, void *src, size_t len,
 }
 
 int
-start_module(struct mbi *mbi, bool uncompress)
+start_module(struct mbi *mbi, bool uncompress, uint64_t phys_max)
 {
   if (((mbi->flags & MBI_FLAG_MODS) == 0) || (mbi->mods_count == 0)) {
     printf("No module to start.\n");
     return -1;
   }
 
-  mbi_relocate_modules(mbi, uncompress);
+  mbi_relocate_modules(mbi, uncompress, phys_max);
 
   // skip module after loading
   struct module *m  = (struct module *) mbi->mods_addr;

--- a/standalone/farnsworth.c
+++ b/standalone/farnsworth.c
@@ -50,5 +50,5 @@ main(uint32_t magic, struct mbi *mbi)
     printf("No memory map!\n");
   }
 
-  return start_module(mbi, false);
+  return start_module(mbi, false, PHYS_MAX_RELOCATE);
 }

--- a/standalone/include/elf.h
+++ b/standalone/include/elf.h
@@ -22,8 +22,9 @@
 #include <stdint.h>
 #include <mbi.h>
 
+enum { PHYS_MAX_RELOCATE = 1ULL << 32 };
 
-int start_module(struct mbi *mbi, bool uncompress);
+int start_module(struct mbi *mbi, bool uncompress, uint64_t phys_max);
 
 /* Definitions taken from elf.h. Copyright follows: */
 /* This file defines standard ELF types, structures, and macros.

--- a/standalone/include/mbi-tools.h
+++ b/standalone/include/mbi-tools.h
@@ -29,7 +29,7 @@ bool mbi_find_memory(const struct mbi *multiboot_info, size_t len,
 
 void *mbi_alloc_protected_memory(struct mbi *multiboot_info, size_t len, unsigned align);
 
-void mbi_relocate_modules(struct mbi *mbi, bool uncompress);
+void mbi_relocate_modules(struct mbi *mbi, bool uncompress, uint64_t phys_max);
 
 
 /* EOF */

--- a/standalone/morbo.c
+++ b/standalone/morbo.c
@@ -146,5 +146,5 @@ main(uint32_t magic, struct mbi *mbi)
   }
 
   /* Will not return if successful. */
-  return start_module(mbi, false);
+  return start_module(mbi, false, PHYS_MAX_RELOCATE);
 }

--- a/standalone/unzip.c
+++ b/standalone/unzip.c
@@ -23,5 +23,5 @@ main(uint32_t magic, struct mbi *mbi)
          "This should be the first boot chainloader, otherwise our simplistic memory\n"
          "management will probably fail.\n");
 
-  return start_module(mbi, true);
+  return start_module(mbi, true, PHYS_MAX_RELOCATE);
 }

--- a/standalone/zapp.c
+++ b/standalone/zapp.c
@@ -246,7 +246,7 @@ main(uint32_t magic, struct mbi *mbi)
   }
  next:
   printf("Starting next module.\n");
-  return start_module(mbi, false);
+  return start_module(mbi, false, PHYS_MAX_RELOCATE);
 }
 
 /* EOF */


### PR DESCRIPTION
(1)
Some older 32bit kernels only supports 1:1 physical-virtual mappings for boot
modules and can't cope with modules lying above 3G physical. There's no
way to map them because of the 1:1 enforcement. Set max physical relocation
memory to 2G.

(2)
Support "256M" commandline option for the upper physical address. The seL4
kernel fails to load if the modules are at the end of the physical memory.
So add a 256M option as upper bound, so that the kernel behind finds free
memory (if you have a machine with less then 256M you're lost of course,
for various other reasons).