### PR TITLE
Fix start.asm for newer nasm version 2.13.03

### DIFF
--- a/standalone/start.asm
+++ b/standalone/start.asm
@@ -1,6 +1,6 @@
         ;; Set stack and jump to _main
 
-        CPU P3
+        CPU 686
         
         EXTERN main, __exit
         GLOBAL _mbheader, _start, jmp_multiboot


### PR DESCRIPTION
Hi there,

I ran into the problem that `bender` does not compile any longer with nasm version 2.13.03.

The reason is that `standalone/start.asm` uses the `CPU P3` directive, and that newer nasm version does not know that (any longer??). With nasm 2.13.02 it works.

(Can someone reproduce that to make sure that i did not f*** up anything else?)

Hopefully `CPU 686` is fine, because that also works with the latest nasm.